### PR TITLE
Fix trophy badge username

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
   >
     <img
       width="800"
-      src="https://github-profile-trophy.vercel.app/?username=iuricode&column=8&theme=darkhub&no-frame=true&no-bg=true"
+      src="https://github-profile-trophy.vercel.app/?username=aldofrota&column=8&theme=darkhub&no-frame=true&no-bg=true"
     />
   </a>
 </p>


### PR DESCRIPTION
## Summary
- fix the GitHub trophy badge to use the repository owner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598c10da84832380e4008fb6cab6c4